### PR TITLE
Skip none iseq frame

### DIFF
--- a/ext/calleree/calleree.c
+++ b/ext/calleree/calleree.c
@@ -47,7 +47,14 @@ eree_called(VALUE tpval, void *ptr)
     VALUE frames[2];
     int lines[2];
     // int start, int limit, VALUE *buff, int *lines);
+
     rb_profile_frames(1, 2, frames, lines);
+
+    // Ignore none iseq frame
+    if (!RB_TYPE_P(frames[0], T_IMEMO) || !RB_TYPE_P(frames[1], T_IMEMO)) {
+      return;
+    }
+
     unsigned int callee_posnum = posnum(data, rb_profile_frame_path(frames[0]), lines[0]);
     unsigned int caller_posnum = posnum(data, rb_profile_frame_path(frames[1]), lines[1]);
 #else


### PR DESCRIPTION
## Problem

Some codes on Ruby 2.7.6 crashed with `frame2iseq: unreachable`

### How to reproduce

```
require "calleree"
Calleree.start

class CrashedClass
  def initialize
    @message_queue = Queue.new
  end

  def start
    Thread.new(&method(:send_loop))
  end

  def send_loop
    @message_queue.pop
  end
end

CrashedClass.new.start

sleep 5
```

### Log

```
debug.rb:14: [BUG] frame2iseq: unreachable
ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin21]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:0001 s:0010 e:000009 METHOD debug.rb:14 [FINISH]
c:0002 p:---- s:0006 e:000005 IFUNC
c:0001 p:---- s:0003 e:000002 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
debug.rb:14:in `send_loop'

-- Other runtime information -----------------------------------------------

* Loaded script: debug.rb

* Loaded features:

...omitted...
[IMPORTANT]
Don't forget to include the Crash Report log file under
DiagnosticReports directory in bug reports.

Abort trap: 6
```